### PR TITLE
remove useless next config

### DIFF
--- a/examples/ssr/next.config.js
+++ b/examples/ssr/next.config.js
@@ -2,24 +2,4 @@ const withPlugins = require("next-compose-plugins");
 const withCSS = require("@zeit/next-css");
 const withFonts = require('next-fonts');
 
-const config = {
-    webpack: (config) => {
-      config.module.rules.push({
-        test: /\.(woff|woff2|eot|ttf)$/,
-        use: [
-          {
-            loader: "file-loader",
-            options: {
-              limit: 1000,
-              name() {
-                return `[name].[ext]`
-              }
-            }
-          }
-        ]
-      });
-      return config;
-    },
-  };
-
 module.exports = withPlugins([withCSS, withFonts], { target: "serverless" });


### PR DESCRIPTION
This code is of no use.

I added the config in `module.export` and and the fonts did not load properly.