### PR TITLE
Added option to skip callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,16 @@ They are very useful in the following cases:
 </Carousel>
 ```
 
+## Skipping callbacks
+
+When calling the `goToSlide` function on a Carousel the callbacks will be run by default. You can skip all or individul callbacks by passing a second parameter to `goToSlide.`
+
+```js
+this.Carousel.goToSlide(1, true); // Skips both beforeChange and afterChange
+this.Carousel.goToSlide(1, { skipBeforeChange: true }); // Skips only beforeChange
+this.Carousel.goToSlide(1, { skipAfterChange: true }); // Skips only afterChange
+```
+
 ## focusOnSelect
 
 Go to slide on click and make the slide a current slide.

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -489,14 +489,14 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       this.autoPlay = undefined;
     }
   }
-  public goToSlide(slide: number): void {
+  public goToSlide(slide: number, skipCallbacks: boolean = false): void {
     if (this.isInThrottle) {
       return;
     }
     const { itemWidth } = this.state;
     const { afterChange, beforeChange } = this.props;
     const previousSlide = this.state.currentSlide;
-    if (typeof beforeChange === "function") {
+    if (!skipCallbacks && typeof beforeChange === "function") {
       beforeChange(slide, this.getState());
     }
     this.isAnimationAllowed = true;
@@ -509,7 +509,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
         if (this.props.infinite) {
           this.correctClonesPosition({ domLoaded: true });
         }
-        if (typeof afterChange === "function") {
+        if (!skipCallbacks && typeof afterChange === "function") {
           setTimeout(() => {
             afterChange(previousSlide, this.getState());
           }, this.props.transitionDuration || defaultTransitionDuration);

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -489,7 +489,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       this.autoPlay = undefined;
     }
   }
-  public goToSlide(slide: number, skipCallbacks: boolean = false): void {
+  public goToSlide(slide: number, skipCallbacks?: boolean): void {
     if (this.isInThrottle) {
       return;
     }
@@ -550,7 +550,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       return React.cloneElement(customButtonGroup, {
         previous: () => this.previous(),
         next: () => this.next(),
-        goToSlide: (slideIndex: number) => this.goToSlide(slideIndex),
+        goToSlide: (slideIndex: number, skipCallbacks?: boolean) => this.goToSlide(slideIndex, skipCallbacks),
         carouselState: this.getState()
       });
     }

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -22,7 +22,8 @@ import {
   CarouselProps,
   StateCallBack,
   Direction,
-  isMouseMoveEvent
+  isMouseMoveEvent,
+  SkipCallbackOptions
 } from "./types";
 import Dots from "./Dots";
 import { LeftArrow, RightArrow } from "./Arrows";
@@ -489,14 +490,18 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       this.autoPlay = undefined;
     }
   }
-  public goToSlide(slide: number, skipCallbacks?: boolean): void {
+  public goToSlide(slide: number, skipCallbacks?: SkipCallbackOptions): void {
     if (this.isInThrottle) {
       return;
     }
     const { itemWidth } = this.state;
     const { afterChange, beforeChange } = this.props;
     const previousSlide = this.state.currentSlide;
-    if (!skipCallbacks && typeof beforeChange === "function") {
+    if (
+      typeof beforeChange === "function" &&
+      (!skipCallbacks ||
+        (typeof skipCallbacks === "object" && !skipCallbacks.skipBeforeChange))
+    ) {
       beforeChange(slide, this.getState());
     }
     this.isAnimationAllowed = true;
@@ -509,7 +514,12 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
         if (this.props.infinite) {
           this.correctClonesPosition({ domLoaded: true });
         }
-        if (!skipCallbacks && typeof afterChange === "function") {
+        if (
+          typeof afterChange === "function" &&
+          (!skipCallbacks ||
+            (typeof skipCallbacks === "object" &&
+              !skipCallbacks.skipAfterChange))
+        ) {
           setTimeout(() => {
             afterChange(previousSlide, this.getState());
           }, this.props.transitionDuration || defaultTransitionDuration);
@@ -550,7 +560,8 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       return React.cloneElement(customButtonGroup, {
         previous: () => this.previous(),
         next: () => this.next(),
-        goToSlide: (slideIndex: number, skipCallbacks?: boolean) => this.goToSlide(slideIndex, skipCallbacks),
+        goToSlide: (slideIndex: number, skipCallbacks?: SkipCallbackOptions) =>
+          this.goToSlide(slideIndex, skipCallbacks),
         carouselState: this.getState()
       });
     }

--- a/src/CarouselItems.tsx
+++ b/src/CarouselItems.tsx
@@ -1,13 +1,17 @@
 import * as React from "react";
 
-import { CarouselInternalState, CarouselProps } from "./types";
+import {
+  CarouselInternalState,
+  CarouselProps,
+  SkipCallbackOptions
+} from "./types";
 import { getInitialState, getIfSlideIsVisbile } from "./utils";
 
 interface CarouselItemsProps {
   props: CarouselProps;
   state: CarouselInternalState;
   clones: any[];
-  goToSlide: (index: number, skipCallbacks?: boolean) => void;
+  goToSlide: (index: number, skipCallbacks?: SkipCallbackOptions) => void;
 }
 
 const CarouselItems = ({

--- a/src/CarouselItems.tsx
+++ b/src/CarouselItems.tsx
@@ -7,7 +7,7 @@ interface CarouselItemsProps {
   props: CarouselProps;
   state: CarouselInternalState;
   clones: any[];
-  goToSlide: (index: number) => void;
+  goToSlide: (index: number, skipCallbacks?: boolean) => void;
 }
 
 const CarouselItems = ({

--- a/src/Dots.tsx
+++ b/src/Dots.tsx
@@ -8,7 +8,7 @@ import { getSlidesToSlide } from "./utils/common";
 interface DotsTypes {
   props: CarouselProps;
   state: CarouselInternalState;
-  goToSlide: (index: number) => void;
+  goToSlide: (index: number, skipCallbacks?: boolean) => void;
   getState: () => StateCallBack;
 }
 const Dots = ({

--- a/src/Dots.tsx
+++ b/src/Dots.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
 
-import { CarouselInternalState, CarouselProps, StateCallBack } from "./types";
+import {
+  CarouselInternalState,
+  CarouselProps,
+  StateCallBack,
+  SkipCallbackOptions
+} from "./types";
 import { getOriginalIndexLookupTableByClones } from "./utils/clones";
 import { getLookupTableForNextSlides } from "./utils/dots";
 import { getSlidesToSlide } from "./utils/common";
@@ -8,7 +13,7 @@ import { getSlidesToSlide } from "./utils/common";
 interface DotsTypes {
   props: CarouselProps;
   state: CarouselInternalState;
-  goToSlide: (index: number, skipCallbacks?: boolean) => void;
+  goToSlide: (index: number, skipCallbacks?: SkipCallbackOptions) => void;
   getState: () => StateCallBack;
 }
 const Dots = ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,10 +62,11 @@ export interface StateCallBack extends CarouselInternalState {
   direction: Direction;
 }
 export type Direction = "left" | "right" | "" | undefined;
+export type SkipCallbackOptions = boolean | { skipBeforeChange?: boolean, skipAfterChange?: boolean }
 export interface ButtonGroupProps {
   previous?: () => void;
   next?: () => void;
-  goToSlide?: (index: number, skipCallbacks?: boolean) => void;
+  goToSlide?: (index: number, skipCallbacks?: SkipCallbackOptions) => void;
   carouselState?: StateCallBack;
 }
 export interface ArrowProps {
@@ -93,7 +94,7 @@ export interface CarouselInternalState {
 export default class Carousel extends React.Component<CarouselProps> {
   previous: (slidesHavePassed: number) => void;
   next: (slidesHavePassed: number) => void;
-  goToSlide: (slide: number, skipCallbacks?: boolean) => void;
+  goToSlide: (slide: number, skipCallbacks?: SkipCallbackOptions) => void;
   state: CarouselInternalState;
   setClones: (
     slidesToShow: number,

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,7 @@ export type Direction = "left" | "right" | "" | undefined;
 export interface ButtonGroupProps {
   previous?: () => void;
   next?: () => void;
-  goToSlide?: (index: number) => void;
+  goToSlide?: (index: number, skipCallbacks?: boolean) => void;
   carouselState?: StateCallBack;
 }
 export interface ArrowProps {
@@ -93,7 +93,7 @@ export interface CarouselInternalState {
 export default class Carousel extends React.Component<CarouselProps> {
   previous: (slidesHavePassed: number) => void;
   next: (slidesHavePassed: number) => void;
-  goToSlide: (slide: number) => void;
+  goToSlide: (slide: number, skipCallbacks?: boolean) => void;
   state: CarouselInternalState;
   setClones: (
     slidesToShow: number,

--- a/test/integration/cases/common/Callbacks.spec.tsx
+++ b/test/integration/cases/common/Callbacks.spec.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+import { configure, mount, ReactWrapper } from "enzyme";
+import * as Adapter from "enzyme-adapter-react-16";
+
+configure({ adapter: new Adapter() });
+
+import Carousel from "../../../../lib/Carousel";
+import Card from "../../components/Card";
+import { responsive1 } from "../../common/responsive";
+import { longData } from "../../common/data";
+
+jest.useFakeTimers();
+
+describe("Callbacks", () => {
+  const beforeChange = jest.fn();
+  const afterChange = jest.fn();
+
+  let wrapper!: ReactWrapper<{}, {}, Carousel>;
+  beforeEach(() => {
+    beforeChange.mockClear();
+    afterChange.mockClear();
+
+    wrapper = mount(
+      <Carousel
+        responsive={responsive1}
+        beforeChange={beforeChange}
+        afterChange={afterChange}
+      >
+        {longData.map(card => (
+          <Card {...card} />
+        ))}
+      </Carousel>
+    );
+  });
+
+  it("calls beforeChange and afterChange", () => {
+    wrapper.instance().goToSlide(1);
+    jest.runOnlyPendingTimers();
+    expect(beforeChange).toHaveBeenCalledTimes(1);
+    expect(afterChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("it skips callbacks as expected", () => {
+    wrapper.instance().goToSlide(1, true);
+    jest.runOnlyPendingTimers();
+    expect(beforeChange).toHaveBeenCalledTimes(0);
+    expect(afterChange).toHaveBeenCalledTimes(0);
+  });
+
+  describe("skipping individual callbacks", () => {
+    it("it skips beforeChange callbacks as expected", () => {
+      wrapper.instance().goToSlide(1, { skipBeforeChange: true });
+      jest.runOnlyPendingTimers();
+      expect(beforeChange).toHaveBeenCalledTimes(0);
+      expect(afterChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("it skips afterChange callbacks as expected", () => {
+      wrapper.instance().goToSlide(1, { skipAfterChange: true });
+      jest.runOnlyPendingTimers();
+      expect(beforeChange).toHaveBeenCalledTimes(1);
+      expect(afterChange).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/test/integration/common/data.ts
+++ b/test/integration/common/data.ts
@@ -34,6 +34,7 @@ const longData = Array(12)
   .fill(0)
   .map((item, index) => {
     return {
+      key: images[index],
       image: images[index],
       headline: "w3js.com - web front-end studio",
       description: texts[index]
@@ -43,6 +44,7 @@ const shortData = Array(5)
   .fill(0)
   .map((item, index) => {
     return {
+      key: images[index],
       image: images[index],
       headline: "w3js.com - web front-end studio",
       description: texts[index]


### PR DESCRIPTION
This PR adds a second optional parameter to `goToSlide` that allows skipping all or individual callbacks.

An example use case is if you are syncing two sliders using a `beforeChange` callback. Calling `Slider1.goToSlide` in `Slider2`'s callback and vice versa would cause an infinite loop.