### PR TITLE
Add aria-label to arrows buttons

### DIFF
--- a/src/Arrows.tsx
+++ b/src/Arrows.tsx
@@ -26,6 +26,7 @@ const LeftArrow = ({
   }
   return (
     <button
+      aria-label="carousel-left-arrow"
       className="react-multiple-carousel__arrow react-multiple-carousel__arrow--left"
       onClick={() => previous()}
     />
@@ -44,6 +45,7 @@ const RightArrow = ({
   }
   return (
     <button
+      aria-label="carousel-right-arrow"
       className="react-multiple-carousel__arrow react-multiple-carousel__arrow--right"
       onClick={() => next()}
     />

--- a/src/Arrows.tsx
+++ b/src/Arrows.tsx
@@ -26,7 +26,7 @@ const LeftArrow = ({
   }
   return (
     <button
-      aria-label="carousel-left-arrow"
+      aria-label="carousel-previous-arrow"
       className="react-multiple-carousel__arrow react-multiple-carousel__arrow--left"
       onClick={() => previous()}
     />
@@ -45,7 +45,7 @@ const RightArrow = ({
   }
   return (
     <button
-      aria-label="carousel-right-arrow"
+      aria-label="carousel-next-arrow"
       className="react-multiple-carousel__arrow react-multiple-carousel__arrow--right"
       onClick={() => next()}
     />

--- a/src/Arrows.tsx
+++ b/src/Arrows.tsx
@@ -26,7 +26,7 @@ const LeftArrow = ({
   }
   return (
     <button
-      aria-label="carousel-previous-arrow"
+      aria-label="Go to previous slide"
       className="react-multiple-carousel__arrow react-multiple-carousel__arrow--left"
       onClick={() => previous()}
     />
@@ -45,7 +45,7 @@ const RightArrow = ({
   }
   return (
     <button
-      aria-label="carousel-next-arrow"
+      aria-label="Go to next slide"
       className="react-multiple-carousel__arrow react-multiple-carousel__arrow--right"
       onClick={() => next()}
     />


### PR DESCRIPTION
### Motivation for this pull request

Lighthouse testing shows that there's no accessible name on the arrows buttons.
<img width="707" alt="Capture d’écran 2019-10-16 à 17 08 23" src="https://user-images.githubusercontent.com/17448102/66933557-8c59ac80-f039-11e9-90e4-40261f9ab591.png">
