### PR TITLE
Improve performance for mouse/touch moving the Carousel.

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -229,12 +229,12 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     if (!isAnimationAllowed && this.isAnimationAllowed) {
       this.isAnimationAllowed = false;
     }
-    const nexTransform = -(itemWidth * this.state.currentSlide);
+    const nextTransform = -(itemWidth * this.state.currentSlide);
     if (setToDomDirectly) {
-      this.setTransformDirectly(nexTransform, true);
+      this.setTransformDirectly(nextTransform, true);
     }
     this.setState({
-      transform: nexTransform
+      transform: nextTransform
     });
   }
   public onResize(value?: React.KeyboardEvent | boolean): void {

--- a/src/CarouselItems.tsx
+++ b/src/CarouselItems.tsx
@@ -20,7 +20,7 @@ const CarouselItems = ({
   goToSlide,
   clones
 }: CarouselItemsProps) => {
-  const { itemWidth, currentSlide } = state;
+  const { itemWidth } = state;
   const { children, infinite, itemClass, partialVisbile } = props;
   const {
     flexBisis,
@@ -63,9 +63,7 @@ const CarouselItems = ({
                   : ""
               } ${itemClass}`}
             >
-              {React.cloneElement(child, {
-                visible: getIfSlideIsVisbile(index, state)
-              })}
+              {child}
             </li>
           );
         }

--- a/src/CarouselItems.tsx
+++ b/src/CarouselItems.tsx
@@ -20,7 +20,7 @@ const CarouselItems = ({
   goToSlide,
   clones
 }: CarouselItemsProps) => {
-  const { itemWidth } = state;
+  const { itemWidth, currentSlide } = state;
   const { children, infinite, itemClass, partialVisbile } = props;
   const {
     flexBisis,
@@ -63,7 +63,9 @@ const CarouselItems = ({
                   : ""
               } ${itemClass}`}
             >
-              {child}
+              {React.cloneElement(child, {
+                visible: getIfSlideIsVisbile(index, state)
+              })}
             </li>
           );
         }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -53,12 +53,14 @@ function getIfSlideIsVisbile(
 
 function getTransformForCenterMode(
   state: CarouselInternalState,
-  props: CarouselProps
+  props: CarouselProps,
+  transformPlaceHolder?: number
 ) {
+  const transform = transformPlaceHolder || state.transform;
   if (state.currentSlide === 0 && !props.infinite) {
-    return state.transform;
+    return transform;
   } else {
-    return state.transform + state.itemWidth / 2;
+    return transform + state.itemWidth / 2;
   }
 }
 
@@ -77,12 +79,15 @@ function isInRightEnd({
 function getTransformForPartialVsibile(
   state: CarouselInternalState,
   partialVisibilityGutter = 0,
-  props: CarouselProps
+  props: CarouselProps,
+  transformPlaceHolder?: number
 ) {
   const { currentSlide, slidesToShow } = state;
   const isRightEndReach = isInRightEnd(state);
   const shouldRemoveRightGutter = !props.infinite && isRightEndReach;
-  const transform = state.transform + currentSlide * partialVisibilityGutter;
+  const transform =
+    (transformPlaceHolder || state.transform) +
+    currentSlide * partialVisibilityGutter;
   if (shouldRemoveRightGutter) {
     const remainingWidth =
       state.containerWidth -
@@ -90,6 +95,32 @@ function getTransformForPartialVsibile(
     return transform + remainingWidth;
   }
   return transform;
+}
+
+function getTransform(
+  state: CarouselInternalState,
+  props: CarouselProps,
+  transformPlaceHolder?: number
+) {
+  const { partialVisbile, responsive, deviceType, centerMode } = props;
+  const transform = transformPlaceHolder || state.transform;
+  const partialVisibilityGutter = getPartialVisibilityGutter(
+    responsive,
+    partialVisbile,
+    deviceType,
+    state.deviceType
+  );
+  const currentTransform = partialVisbile
+    ? getTransformForPartialVsibile(
+        state,
+        partialVisibilityGutter,
+        props,
+        transformPlaceHolder
+      )
+    : centerMode
+    ? getTransformForCenterMode(state, props, transformPlaceHolder)
+    : transform;
+  return currentTransform;
 }
 
 function notEnoughChildren(
@@ -145,5 +176,6 @@ export {
   getTransformForCenterMode,
   getTransformForPartialVsibile,
   notEnoughChildren,
-  getSlidesToSlide
+  getSlidesToSlide,
+  getTransform
 };

--- a/src/utils/mouseOrTouchMove.ts
+++ b/src/utils/mouseOrTouchMove.ts
@@ -6,7 +6,8 @@ function populateSlidesOnMouseTouchMove(
   props: CarouselProps,
   initialX: number,
   lastX: number,
-  clientX: number
+  clientX: number,
+  transformPlaceHolder: number
 ): {
   direction?: Direction;
   nextPosition: number | undefined;
@@ -16,7 +17,6 @@ function populateSlidesOnMouseTouchMove(
     itemWidth,
     slidesToShow,
     totalItems,
-    transform,
     currentSlide
   } = state;
   const { infinite } = props;
@@ -35,7 +35,7 @@ function populateSlidesOnMouseTouchMove(
       const translateXLimit = Math.abs(
         -(itemWidth * (totalItems - slidesToShow))
       );
-      const nextTranslate = transform - (lastX - clientX);
+      const nextTranslate = transformPlaceHolder - (lastX - clientX);
       const isLastSlide = currentSlide === totalItems - slidesToShow;
       if (
         Math.abs(nextTranslate) <= translateXLimit ||
@@ -50,7 +50,7 @@ function populateSlidesOnMouseTouchMove(
     const isAboutToOverSlide = !(slidesHavePassedLeft <= slidesToShow);
     if (!isAboutToOverSlide) {
       direction = "left";
-      const nextTranslate = transform + (clientX - lastX);
+      const nextTranslate = transformPlaceHolder + (clientX - lastX);
       const isFirstSlide = currentSlide === 0;
       if (nextTranslate <= 0 || (isFirstSlide && infinite)) {
         canContinue = true;

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -9,7 +9,7 @@ two cases:
 function populateNextSlides(
   state: CarouselInternalState,
   props: CarouselProps,
-  slidesHavePassed = 0
+  slidesHavePassed = 0,
 ): {
   nextSlides: number | undefined;
   nextPosition: number | undefined;

--- a/test/unit/mouseOrTouchMove.spec.ts
+++ b/test/unit/mouseOrTouchMove.spec.ts
@@ -7,7 +7,6 @@ describe("Mouse move and touch functionality", () => {
       currentSlide: 2,
       itemWidth: 250,
       totalItems: 4,
-      slidesHavePassed: 2,
       transform: 2000
     };
     const props = {
@@ -21,7 +20,8 @@ describe("Mouse move and touch functionality", () => {
       props,
       initialPosition,
       lastPosition,
-      clientX
+      clientX,
+      2000
     );
     expect(results).toEqual({
       direction: "right",
@@ -35,8 +35,7 @@ describe("Mouse move and touch functionality", () => {
       currentSlide: 2,
       itemWidth: 250,
       totalItems: 4,
-      slidesHavePassed: 2,
-      transform: 2000
+      slidesHavePassed: 2
     };
     const props = {
       slidesToSlide: 1
@@ -49,7 +48,8 @@ describe("Mouse move and touch functionality", () => {
       props,
       initialPosition,
       lastPosition,
-      clientX
+      clientX,
+      2000
     );
     expect(results).toEqual({
       direction: "left",
@@ -63,8 +63,7 @@ describe("Mouse move and touch functionality", () => {
       currentSlide: 2,
       itemWidth: 250,
       totalItems: 8,
-      slidesHavePassed: 2,
-      transform: 2000
+      slidesHavePassed: 2
     };
     const props = {
       slidesToSlide: 1
@@ -77,7 +76,8 @@ describe("Mouse move and touch functionality", () => {
       props,
       initialPosition,
       lastPosition,
-      clientX
+      clientX,
+      2000
     );
     expect(results).toEqual({
       direction: "right",
@@ -91,8 +91,7 @@ describe("Mouse move and touch functionality", () => {
       currentSlide: 5,
       itemWidth: 250,
       totalItems: 8,
-      slidesHavePassed: 2,
-      transform: 600
+      slidesHavePassed: 2
     };
     const props = {
       slidesToSlide: 1
@@ -105,7 +104,8 @@ describe("Mouse move and touch functionality", () => {
       props,
       initialPosition,
       lastPosition,
-      clientX
+      clientX,
+      600
     );
     expect(results).toEqual({
       direction: "left",


### PR DESCRIPTION
Previously when handling mouse and touch moving the carousel it was using ```this.setState()``` method. Now the Carousel it's faster with less re-renderings by directly manipulating the Dom to change the transform, afterwards sync the value to the react state.

I am currently working on a new version of the Carousel to re-write it using hooks.