### PR TITLE
feat: add activeItemClass prop

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -40,6 +40,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     containerClass: "",
     sliderClass: "",
     itemClass: "",
+    activeItemClass: "",
     keyBoardControl: true,
     autoPlaySpeed: 3000,
     showDots: false,

--- a/src/CarouselItems.tsx
+++ b/src/CarouselItems.tsx
@@ -27,6 +27,7 @@ const CarouselItems = ({
     children,
     infinite,
     itemClass,
+    activeItemClass,
     partialVisbile,
     partialVisible
   } = props;
@@ -75,7 +76,7 @@ const CarouselItems = ({
               }}
               className={`react-multi-carousel-item ${
                 getIfSlideIsVisbile(index, state)
-                  ? "react-multi-carousel-item--active"
+                  ? `react-multi-carousel-item--active ${activeItemClass}`
                   : ""
               } ${itemClass}`}
             >

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface CarouselProps {
   beforeChange?: (nextSlide: number, state: StateCallBack) => void; // Change callback before sliding everytime. `(previousSlide, currentState) => ...`
   sliderClass?: string; // Use this to style your own track list.
   itemClass?: string; // Use this to style your own Carousel item. For example add padding-left and padding-right
+  activeItemClass?: string; // Use this to style your own active Carousel item.
   containerClass?: string; // Use this to style the whole container. For example add padding to allow the "dots" or "arrows" to go to other places without being overflown.
   className?: string; // Use this to style the whole container with styled-components
   dotListClass?: string; // Use this to style the dot list.
@@ -56,7 +57,6 @@ export interface CarouselProps {
   focusOnSelect?: boolean;
   additionalTransfrom?: number; // this is only used if you want to add additional transfrom to the current transform
 }
-
 
 export type StateCallBack = CarouselInternalState;
 


### PR DESCRIPTION
`react-multi-carousel` is lacking a way to style the active item(s) without overriding the class defined by the package itself (`react-multi-carousel-item--active`).

I think that this does not fit well when you are using CSS in JS or CSS Modules, so I added a new `prop` called `activeItemClass` that accepts a class.

Usage:

- CSS Modules

```css
.foo {
	border: 1px solid red;
}
```

```jsx
import styles from "Styles.module.css";

const Component = () => (
	<Carousel activeItemClass={styles.foo}>
	  // ...slides
	</Carousel>
);
```

- MUI (withStyles HOC)

```jsx
const styles = theme => ({
	foo: {
		border: "1px solid red",
	}
})

const Component = ({ classes })) => (
	<Carousel activeItemClass={classes.foo}>
	  // ...slides
	</Carousel>
);
```

```html
<li class="react-multi-carousel-item react-multi-carousel-item--active foo">...</li>
```

Preview:

![Screen Shot 2020-01-21 at 17 36 32](https://user-images.githubusercontent.com/8797405/72829338-7da51600-3c76-11ea-839b-e371c328739a.png)

```html
<li data-index="2" aria-hidden="false" style="flex: 1 1 auto; position: relative; width: 275px;" class="react-multi-carousel-item react-multi-carousel-item--active Index-activeItemClass-150 image-item"><img draggable="false" style="width: 100%; height: 100%; position: relative;" src="https://images.unsplash.com/photo-1550133730-695473e544be?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" alt="w3js -> web front-end studio"></li>
```

If this feature makes sense to the project I'd be glad to help updating the docs and doing any work related to this feature.

Thanks!
 