### PR TITLE
updated CustomRightArrow useage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ You custom arrows will receive a list of props/state that's passed back by the c
 const CustomRightArrow = ({ onClick, ...rest }) => {
   const {
     onMove,
-    state: { currentSlide, deviceType },
+    carouselState: { currentSlide, deviceType },
   } = rest;
   // onMove means if dragging or swiping in progress.
   return <button onClick={() => onClick()} />;


### PR DESCRIPTION
I was trying to to create custom buttons but there was error

```
×
TypeError: Cannot read property 'currentSlide' of undefined
CustomRightArrow
src/appcomponents/DivCarousel/ScrollingDiv.js:15
  12 | console.log(onClick,rest,'c1')
  13 | const {
  14 |   onMove,
> 15 |   state: { currentSlide, deviceType },
     | ^  16 | } = rest;
  17 | // onMove means if dragging or swiping in progress.
  18 | return (
```

on inspecting i found that instead of using `state` i will have to use `carouselState` as opposed to official docs on NPM and GitHub as well.


i don't see any PR open for this so creating this one