### PR TITLE
Clear items to show resize timeout when component unmounts (Issue #87)

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -63,6 +63,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
   public isInThrottle?: boolean;
   public initialY: number;
   private transformPlaceHolder: number;
+  private itemsToShowTimeout: any;
   constructor(props: CarouselProps) {
     super(props);
     this.containerRef = React.createRef();
@@ -301,7 +302,10 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       this.containerRef.current.offsetWidth !== containerWidth
     ) {
       // this is for handling resizing only.
-      setTimeout(() => {
+      if (this.itemsToShowTimeout) {
+        clearTimeout(this.itemsToShowTimeout);
+      }
+      this.itemsToShowTimeout = setTimeout(() => {
         this.setItemsToShow(true);
       }, this.props.transitionDuration || defaultTransitionDuration);
     }
@@ -456,6 +460,9 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     if (this.props.autoPlay && this.autoPlay) {
       clearInterval(this.autoPlay);
       this.autoPlay = undefined;
+    }
+    if (this.itemsToShowTimeout) {
+      clearTimeout(this.itemsToShowTimeout);
     }
   }
   public resetMoveStatus(): void {


### PR DESCRIPTION
As described in issue #87 , there is an occasional error indicating a memory leak occasionally when the component mounts, especially (but not exclusively) when resizing.

Clearing this/these timeout(s) on unmount prevents the error.

**Error:**
```
Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
```

To most easily reproduce the problem without this change, resize the window while the page is loading.