### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Big thanks to [BrowserStack](https://www.browserstack.com) for letting the maint
 ## Bundle size
 
 [Bundle-size](https://bundlephobia.com/result?p=react-multi-carousel).
-2.5kB
+22.5kB
 
 ## Demo.
 


### PR DESCRIPTION
Bundlephobia (the linked page) states a size of 22.5 kb, not 2.5 kb