### PR TITLE
Added button type for ArrowButton

### DIFF
--- a/src/Arrows.tsx
+++ b/src/Arrows.tsx
@@ -29,6 +29,7 @@ const LeftArrow = ({
       aria-label="Go to previous slide"
       className="react-multiple-carousel__arrow react-multiple-carousel__arrow--left"
       onClick={() => previous()}
+      type="button"
     />
   );
 };
@@ -48,6 +49,7 @@ const RightArrow = ({
       aria-label="Go to next slide"
       className="react-multiple-carousel__arrow react-multiple-carousel__arrow--right"
       onClick={() => next()}
+      type="button"
     />
   );
 };


### PR DESCRIPTION
If the carousel is used in a form, the arrow button
has type="submit" by default and sends the form.
Added the type="button" to the buttons.