### PR TITLE
Remove partialVisibilityGutter when totalItems is equal to slidesToShow

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -6,7 +6,7 @@ import { CarouselInternalState, CarouselProps } from "../types";
 
 function notEnoughChildren(state: CarouselInternalState): boolean {
   const { slidesToShow, totalItems } = state;
-  return totalItems < slidesToShow;
+  return totalItems <= slidesToShow;
 }
 
 function getInitialState(


### PR DESCRIPTION
Follow pull-request #111

There should be notEnoughChildren if slidesToShow is equal to totalItems

It allow to remove partialVisibilityGutter when there is the same count of items