### PR TITLE
fix partial visible

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -90,11 +90,11 @@ function getTransformForPartialVsibile(
   props: CarouselProps,
   transformPlaceHolder?: number
 ) {
-  const { currentSlide, slidesToShow } = state;
+  const { totalItems, currentSlide, slidesToShow } = state;
   const isRightEndReach = isInRightEnd(state);
   const shouldRemoveRightGutter = !props.infinite && isRightEndReach;
   const baseTransform = transformPlaceHolder || state.transform;
-  if (notEnoughChildren(state)) {
+  if (totalItems <= slidesToShow) {
     return baseTransform;
   }
   const transform = baseTransform + currentSlide * partialVisibilityGutter;


### PR DESCRIPTION
Follow pull-request #111 and #218

There should be notEnoughChildren if slidesToShow is equal to totalItems
It allow to remove partialVisibilityGutter when there is the same count of items

Normally there is less impact with this fix.
