### PR TITLE
Add font-display:block to font-face load

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -1,6 +1,7 @@
 @font-face {
   font-family: "revicons";
   fallback: fallback;
+  font-display: block;
   src: url("./revicons.woff") format('woff'),
   url("./revicons.ttf") format('ttf'),
   url("./revicons.eot") format('ttf');


### PR DESCRIPTION
Adding `font-display: block` to the `@font-face` loader is recomended for icon fonts (as revicons in this case). This will prevent any visible text paint flash (slow connections) and google lighthouse to add negative score to the page using this library. 

You can check out the advantages and differences between `font-display` properties in these posts from **CSS Tricks** and this blog post regarding this issue:

https://css-tricks.com/font-display-masses/
https://css-tricks.com/hey-hey-font-display/
https://www.zachleat.com/web/font-display-icon-fonts/

> block: Like FOIT, but the invisibility period persists indefinitely. Use this value any time blocking rendering of text for a potentially indefinite period of time would be preferable.

> Wanna hear something quite unfortunate? We already mentioned font-display: block;. Wouldn’t you think it, uh, well, blocked the rendering of text until the custom font loads? It doesn’t. It’s still got a swap period. It would be the perfect thing for something like icon fonts where the icon (probably) has no meaning unless the custom font loads. Alas, there is no font-display solution for that.

> Using font-display: block is the default behavior and will use invisible text for up to 3 seconds and show fallback text until the web font load completes: The best option but still not good.

As you can see, there's not an optimal solution to using `font-display` with icon fonts (like revicons in the use case of this library), but to both bypass the lighthouse score hit and the initial render with no fonts available, using `block` is definitely the best option we have as developers.

The lighthouse issue:

<img width="586" alt="Screenshot 2021-01-05 at 19 04 26" src="https://user-images.githubusercontent.com/26143855/103684238-8e37c480-4f8b-11eb-83ee-996e56762a74.png">
