### PR TITLE
Added Fix for using tab to slide through the carousel list

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -452,13 +452,15 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     );
   }
   public componentWillUnmount(): void {
-    window.removeEventListener("resize", this.onResize as React.EventHandler<
-      any
-    >);
+    window.removeEventListener(
+      "resize",
+      this.onResize as React.EventHandler<any>
+    );
     if (this.props.keyBoardControl) {
-      window.removeEventListener("keyup", this.onKeyUp as React.EventHandler<
-        any
-      >);
+      window.removeEventListener(
+        "keyup",
+        this.onKeyUp as React.EventHandler<any>
+      );
     }
     if (this.props.autoPlay && this.autoPlay) {
       clearInterval(this.autoPlay);
@@ -484,7 +486,6 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       return;
     }
     const { clientX, clientY } = isMouseMoveEvent(e) ? e : e.touches[0];
-    console.log('{ clientX, clientY }', { clientX, clientY });
     this.onMove = true;
     this.initialX = clientX;
     this.initialY = clientY;

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -312,9 +312,10 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       }, this.props.transitionDuration || defaultTransitionDuration);
     }
     if (keyBoardControl && !this.props.keyBoardControl) {
-      window.removeEventListener("keyup", this.onKeyUp as React.EventHandler<
-        any
-      >);
+      window.removeEventListener(
+        "keyup",
+        this.onKeyUp as React.EventHandler<any>
+      );
     }
     if (!keyBoardControl && this.props.keyBoardControl) {
       window.addEventListener("keyup", this.onKeyUp as React.EventHandler<any>);
@@ -483,6 +484,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       return;
     }
     const { clientX, clientY } = isMouseMoveEvent(e) ? e : e.touches[0];
+    console.log('{ clientX, clientY }', { clientX, clientY });
     this.onMove = true;
     this.initialX = clientX;
     this.initialY = clientY;
@@ -577,12 +579,46 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       this.resetMoveStatus();
     }
   }
+  private isInViewport(el: HTMLInputElement) {
+    const {
+      top = 0,
+      left = 0,
+      bottom = 0,
+      right = 0
+    } = el.getBoundingClientRect();
+    return (
+      top >= 0 &&
+      left >= 0 &&
+      bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+      right <= (window.innerWidth || document.documentElement.clientWidth)
+    );
+  }
+
+  private isChildOfCarousel(el: EventTarget) {
+    if (el instanceof Element && this.listRef && this.listRef.current) {
+      return this.listRef.current.contains(el);
+    }
+    return false;
+  }
+
   public onKeyUp(e: React.KeyboardEvent): void {
-    switch (e.keyCode) {
+    const { target, keyCode } = e;
+    switch (keyCode) {
       case 37:
-        return this.previous();
+        if (this.isChildOfCarousel(target)) return this.previous();
+        break;
       case 39:
-        return this.next();
+        if (this.isChildOfCarousel(target)) return this.next();
+        break;
+      case 9:
+        if (
+          this.isChildOfCarousel(target) &&
+          target instanceof HTMLInputElement &&
+          !this.isInViewport(target)
+        ) {
+          return this.next();
+        }
+        break;
     }
   }
   public handleEnter(): void {


### PR DESCRIPTION
This PR aims to fix the accessibility issue raised in https://github.com/YIZHUANG/react-multi-carousel/issues/233#issue-823071351 

## Summary:

Describe the bug
Hello, thank you for such a great library, it helps me a lot, but recently I have stumbled upon the following bug. The carousel arrows do not get updated when navigating the carousel with keyboard focus - TAB.

To Reproduce
Steps to reproduce the behaviour:

Go to https://w3js.com/react-multi-carousel
After the example loads, click on the first carousel item
Press TAB multiple times on the keyboard to change focus to the next carousel items.
See how the arrows on the carousel stay at the same place despite the carousel being moved to another item.
Expected behaviour
The position of arrows should be updated.


## Fix

This fix also limits Arrow key control which tends to move all Carousel present in a given page to only active / selected carousel. See Gif below for working fix

![ezgif-3-29728a93b08e](https://user-images.githubusercontent.com/5404682/117858609-e71daf00-b242-11eb-9314-9e16b5ae1b67.gif)

