### PR TITLE
Add font swap

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -4,6 +4,7 @@
   src: url("./revicons.woff") format('woff'),
   url("./revicons.ttf") format('ttf'),
   url("./revicons.eot") format('ttf');
+  font-display: swap;
 }
 .react-multi-carousel-list {
   display: flex;


### PR DESCRIPTION
To improve SEO optimization using Google Tools, all webfonts should be swapped to ensure text remains visible during webfont load ([Link to more info](https://web.dev/font-display/?utm_source=lighthouse&utm_medium=devtools))

This PR add `font-display: swap` to CSS core to meet specified requirements.