### PR TITLE
Add body scroll lock while swiping

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -497,6 +497,8 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     ) {
       return;
     }
+    const body = document.body;
+    body.classList.add("react-multi-carousel-scroll-lock");
     const { clientX, clientY } = isMouseMoveEvent(e) ? e : e.touches[0];
     const diffX = this.initialX - clientX;
     const diffY = this.initialY - clientY;
@@ -539,6 +541,8 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     if (shouldDisableOnMobile || shouldDisableOnDesktop) {
       return;
     }
+    const body = document.body;
+    body.classList.remove("react-multi-carousel-scroll-lock");
     if (this.onMove) {
       this.setAnimationDirectly(true);
       if (this.direction === "right") {

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -5,6 +5,9 @@
   url("./revicons.ttf") format('ttf'),
   url("./revicons.eot") format('ttf');
 }
+body.react-multi-carousel-scroll-lock {
+  overflow: hidden;
+}
 .react-multi-carousel-list {
   display: flex;
   align-items: center;


### PR DESCRIPTION
I had an issue when using multiple carousel items on the same page (Netflix like)
Users don't usually swipe horizontally at 90 degrees, so the site ends up moving a bit up or down.

This should be enough to improve the UX by avoiding that body scroll while swiping 