### PR TITLE
Fix code mode for types in README Props table

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,10 +478,10 @@ For example if you give to your carousel item padding left and padding right 20p
 | renderDotsOutside       |                                                                     `boolean`                                                                      |              `false`              | Show dots outside of the container                                                                                                                                    |
 | partialVisible          |                                                                 `boolean` | `string`                                                                 |              `false`              | Show partial next slides. This is use with the `responsive` prop, see example for details                                                                             |
 | customTransition        |                                                                      `string`                                                                      |   `transform 300ms ease-in-out`   | Configure your own anaimation when sliding                                                                                                                            |
-| transitionDuration      | `number |`300` | The unit is ms, if you are using customTransition, make sure to put the duration here as this is needed for the resizing to work. |
-| focusOnSelect           |                                    `boolean |`false` | Go to slide on click and make the slide a current slide.                                    |
-| centerMode              |                                       `boolean |`false` | Shows the next items and previous items partially.                                       |
-| additionalTransfrom     |                                              `number |`0` | additional transfrom to the current one.                                               |
+| transitionDuration      | `number` |`300` | The unit is ms, if you are using customTransition, make sure to put the duration here as this is needed for the resizing to work. |
+| focusOnSelect           |                                    `boolean` |`false` | Go to slide on click and make the slide a current slide.                                    |
+| centerMode              |                                       `boolean` |`false` | Shows the next items and previous items partially.                                       |
+| additionalTransfrom     |                                              `number` |`0` | additional transfrom to the current one.                                               |
 
 ## Author
 


### PR DESCRIPTION
Some of the types weren't properly escaped for the props table in the README. 
This change just ensures they are properly escaped with the correct `\`` syntax