### PR TITLE
skipAnimation on goToSlide

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -628,7 +628,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       this.autoPlay = undefined;
     }
   }
-  public goToSlide(slide: number, skipCallbacks?: SkipCallbackOptions): void {
+  public goToSlide(slide: number, skipCallbacks?: SkipCallbackOptions, skipAnimation?: boolean): void {
     if (this.isInThrottle) {
       return;
     }
@@ -642,7 +642,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     ) {
       beforeChange(slide, this.getState());
     }
-    this.isAnimationAllowed = true;
+    this.isAnimationAllowed = !skipAnimation;
     this.props.shouldResetAutoplay && this.resetAutoplayInterval();
     this.setState(
       {


### PR DESCRIPTION
Provide option to skip animation when going to slide, if user wants to move to a slide instantaneously. Should be non-breaking change, and skipCallbacks should still work as is. 

Please test and give feedback! :)