### PR TITLE
Fixed autoPlaySpeed type and disabled animation for rewind

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,8 @@ For example if you give to your carousel item padding left and padding right 20p
 | centerMode              |                                       `boolean` |`false` | Shows the next items and previous items partially.                                       |
 | additionalTransfrom     |                                              `number` |`0` | additional transfrom to the current one.                                               |
 | shouldResetAutoplay     |                                              `boolean` |`true` | resets autoplay when clicking next, previous button and the dots                                              |
-| rewind     |                                              `boolean` |`false` | if infinite is not enabled and autoPlay explicitly is, this option rewinds the carousel when the end is reached (Lightweight infinite mode alternative without cloning).                                              |
+| rewind     |                                              `boolean` |`false` | if infinite is not enabled and autoPlay explicitly is, this option rewinds the carousel when the end is reached (Lightweight infinite mode alternative without cloning).
+| rewindWithAnimation     |                                              `boolean` |`false` | when rewinding the carousel back to the beginning, this decides if the rewind process should be instant or with transition.                                             |
 
 ## Author
 

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -356,13 +356,14 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
      If we reach the last slide of a non-infinite carousel we can rewind the carousel
      if opted in to autoPlay (lightweight infinite mode alternative).
     */
-     if (this.props.autoPlay && this.props.rewind) {
+    if (this.props.autoPlay && this.props.rewind && this.props.autoPlaySpeed) {
       if (!this.props.infinite && isInRightEnd(this.state)) {
-        const rewindBuffer = this.props.transitionDuration || defaultTransitionDuration;
+        const rewindBuffer =
+          this.props.transitionDuration || defaultTransitionDuration;
         setTimeout(() => {
           this.setIsInThrottle(false);
           this.resetAutoplayInterval();
-          this.goToSlide(0);
+          this.goToSlide(0, undefined, false);
         }, rewindBuffer + this.props.autoPlaySpeed);
       }
     }
@@ -643,7 +644,11 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       this.autoPlay = undefined;
     }
   }
-  public goToSlide(slide: number, skipCallbacks?: SkipCallbackOptions): void {
+  public goToSlide(
+    slide: number,
+    skipCallbacks?: SkipCallbackOptions,
+    animationAllowed = true
+  ): void {
     if (this.isInThrottle) {
       return;
     }
@@ -657,7 +662,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     ) {
       beforeChange(slide, this.getState());
     }
-    this.isAnimationAllowed = true;
+    this.isAnimationAllowed = animationAllowed;
     this.props.shouldResetAutoplay && this.resetAutoplayInterval();
     this.setState(
       {

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -54,7 +54,8 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     additionalTransfrom: 0,
     pauseOnHover: true,
     shouldResetAutoplay: true,
-    rewind: false
+    rewind: false,
+    rewindWithAnimation: false
   };
   private readonly containerRef: React.RefObject<HTMLDivElement>;
   private readonly listRef: React.RefObject<HTMLUListElement>;
@@ -363,7 +364,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
         setTimeout(() => {
           this.setIsInThrottle(false);
           this.resetAutoplayInterval();
-          this.goToSlide(0, undefined, false);
+          this.goToSlide(0, undefined, !!this.props.rewindWithAnimation);
         }, rewindBuffer + this.props.autoPlaySpeed);
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export interface CarouselProps {
   pauseOnHover?: boolean;
   shouldResetAutoplay?: boolean;
   rewind?: boolean;
+  rewindWithAnimation?: boolean;
 }
 
 export type StateCallBack = CarouselInternalState;

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -14,7 +14,7 @@ import {
   CustomLeftArrow,
   CustomRightArrow,
   CustomButtonGroup,
-  CustomButtonGroupAsArrows,
+  CustomButtonGroupAsArrows
 } from "./CustomArrows";
 import CopyOfChildAsDots from "./CopyOfChildAsDots";
 import CustomDot from "./CustomDot";
@@ -43,14 +43,14 @@ const images = [
   "https://images.unsplash.com/photo-1549737328-8b9f3252b927?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=60",
   "https://images.unsplash.com/photo-1549833284-6a7df91c1f65?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=60",
   "https://images.unsplash.com/photo-1549985908-597a09ef0a7c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=60",
-  "https://images.unsplash.com/photo-1550064824-8f993041ffd3?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=60",
+  "https://images.unsplash.com/photo-1550064824-8f993041ffd3?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=60"
 ];
 const texts = [
   "Appending currency sign to a purchase form in your e-commerce site using plain JavaScript.",
   "Fixing CSS load order/style.chunk.css incorrect in Nextjs",
   "React Carousel with Server Side Rendering Support – Part 1",
   "React Carousel with Server Side Rendering Support – Part 2",
-  "Flutter Xcode couldn’t find any iOS App Development provisioning profiles",
+  "Flutter Xcode couldn’t find any iOS App Development provisioning profiles"
 ];
 const fakerData = Array(12)
   .fill(0)
@@ -59,7 +59,7 @@ const fakerData = Array(12)
     return {
       image: images[index],
       headline: "w3js.com - web front-end studio",
-      description: texts[number],
+      description: texts[number]
     };
   });
 
@@ -67,33 +67,33 @@ const responsive = {
   desktop: {
     breakpoint: { max: 3000, min: 1024 },
     items: 3,
-    partialVisibilityGutter: 40, // this is optional if you are not using partialVisible props
+    partialVisibilityGutter: 40 // this is optional if you are not using partialVisible props
   },
   tablet: {
     breakpoint: { max: 1024, min: 464 },
     items: 2,
-    partialVisibilityGutter: 30, // this is optional if you are not using partialVisible props
+    partialVisibilityGutter: 30 // this is optional if you are not using partialVisible props
   },
   mobile: {
     breakpoint: { max: 464, min: 0 },
     items: 1,
-    partialVisibilityGutter: 30, // this is optional if you are not using partialVisible props
-  },
+    partialVisibilityGutter: 30 // this is optional if you are not using partialVisible props
+  }
 };
 
 const responsiveImageHero = {
   desktop: {
     breakpoint: { max: 3000, min: 1024 },
-    items: 1,
+    items: 1
   },
   tablet: {
     breakpoint: { max: 1024, min: 464 },
-    items: 1,
+    items: 1
   },
   mobile: {
     breakpoint: { max: 464, min: 0 },
-    items: 1,
-  },
+    items: 1
+  }
 };
 
 storiesOf("Carousel", module)
@@ -180,7 +180,23 @@ storiesOf("Carousel", module)
   .addWithJSX("With custom control functionality", () => {
     return <WithScrollbar />;
   })
-  .addWithJSX("Auto play", () => {
+  .addWithJSX("Auto play with rewind in non-infinite mode", () => {
+    return (
+      <Carousel
+        autoPlay
+        rewind
+        autoPlaySpeed={1000}
+        containerClass="container-with-dots"
+        slidesToSlide={2}
+        responsive={responsive}
+      >
+        {fakerData.map(card => {
+          return <Card {...card} />;
+        })}
+      </Carousel>
+    );
+  })
+  .addWithJSX("Auto play in infinite mode", () => {
     return (
       <Carousel
         autoPlay
@@ -232,7 +248,7 @@ storiesOf("Carousel", module)
                 width: "100%",
                 display: "block",
                 height: "100%",
-                margin: "auto",
+                margin: "auto"
               }}
             />
           );
@@ -262,7 +278,7 @@ storiesOf("Carousel", module)
                     width: "100%",
                     display: "block",
                     height: "100%",
-                    margin: "auto",
+                    margin: "auto"
                   }}
                 />
               );
@@ -291,7 +307,7 @@ storiesOf("Carousel", module)
                 width: "100%",
                 display: "block",
                 height: "100%",
-                margin: "auto",
+                margin: "auto"
               }}
             />
           );
@@ -406,7 +422,7 @@ storiesOf("Carousel", module)
     return (
       <div
         style={{
-          position: "relative",
+          position: "relative"
         }}
       >
         <Carousel


### PR DESCRIPTION
Changes:

1. Fixed the autoPlaySpeed type that it can be undefined causing the build to fail
2. Made it so rewinding will not have animation, because i see that it jumps quite a bit if the list is large. But the transition can be enabled by passing ```rewindWithAnimation``` to true