### PR TITLE
Add custom Active Class to speciied items

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -41,6 +41,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     containerClass: "",
     sliderClass: "",
     itemClass: "",
+    itemActiveClass: null,
     keyBoardControl: true,
     autoPlaySpeed: 3000,
     showDots: false,
@@ -356,9 +357,10 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
      If we reach the last slide of a non-infinite carousel we can rewind the carousel
      if opted in to autoPlay (lightweight infinite mode alternative).
     */
-     if (this.props.autoPlay && this.props.rewind) {
+    if (this.props.autoPlay && this.props.rewind) {
       if (!this.props.infinite && isInRightEnd(this.state)) {
-        const rewindBuffer = this.props.transitionDuration || defaultTransitionDuration;
+        const rewindBuffer =
+          this.props.transitionDuration || defaultTransitionDuration;
         setTimeout(() => {
           this.setIsInThrottle(false);
           this.resetAutoplayInterval();

--- a/src/CarouselItems.tsx
+++ b/src/CarouselItems.tsx
@@ -27,6 +27,7 @@ const CarouselItems = ({
     children,
     infinite,
     itemClass,
+    itemActiveClass,
     itemAriaLabel,
     partialVisbile,
     partialVisible
@@ -86,7 +87,13 @@ const CarouselItems = ({
                 getIfSlideIsVisbile(index, state)
                   ? "react-multi-carousel-item--active"
                   : ""
-              } ${itemClass}`}
+              } ${itemClass} ${
+                itemActiveClass &&
+                itemActiveClass.index.length > 0 &&
+                itemActiveClass.index.findIndex(i => i === index) !== -1
+                  ? itemActiveClass.className
+                  : ""
+              }`}
             >
               {child}
             </li>

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,11 @@ export interface CarouselProps {
   beforeChange?: (nextSlide: number, state: StateCallBack) => void; // Change callback before sliding everytime. `(previousSlide, currentState) => ...`
   sliderClass?: string; // Use this to style your own track list.
   itemClass?: string; // Use this to style your own Carousel item. For example add padding-left and padding-right
+  itemActiveClass?: {
+    // Use this to style your own Active Carousel item. For example add different size or color when hover or selected
+    index: number[];
+    className: string;
+  };
   itemAriaLabel?: string; // Use this to add your own Carousel item aria-label.if it is not defined the child aria label will be applied if the child dont have one than a default empty string will be applied
   containerClass?: string; // Use this to style the whole container. For example add padding to allow the "dots" or "arrows" to go to other places without being overflown.
   className?: string; // Use this to style the whole container with styled-components


### PR DESCRIPTION
Hey

This change allows setting a custom active class to the specified idex items
Can be used to set a special height or background color to the selected or active items, and not all 

Example: 

https://user-images.githubusercontent.com/26827563/167489981-e3ff8a8e-ecb1-4074-a116-d3d5165e7e62.mov



I notice this PR https://github.com/YIZHUANG/react-multi-carousel/pull/125 But it doesn't quite work as I needed here.
I hope this is helpful 

Usage:

```javascript
<Carousel
  activeItemClass={{
    index:[1],
    className: "active",
  }}
...
/>
```

For anyone needing the same grow effect here's the CSS 

```css
.carousel ul li.active,
.carousel ul li:hover,
.carousel ul li.active,
.carousel ul li:hover {
  transition-delay: 0.5s;
  -webkit-transform: scale(1.2);
  transform: scale(1.2);
  margin: 0 30px;
  width: 290px !important;
}

```