### PR TITLE
Clear timeouts on component unmount to prevent memory leaks

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -70,6 +70,13 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
   public initialY: number;
   private transformPlaceHolder: number;
   private itemsToShowTimeout: any;
+  static clonesTimeout: any;
+  static isInThrottleTimeout: any;
+  static transformTimeout: any;
+  static afterChangeTimeout: any;
+  static afterChangeTimeout2: any;
+  static afterChangeTimeout3: any;
+
   constructor(props: CarouselProps) {
     super(props);
     this.containerRef = React.createRef();
@@ -336,7 +343,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     }
     if (children.length !== this.props.children.length) {
       // this is for handling changing children only.
-      setTimeout(() => {
+      Carousel.clonesTimeout = setTimeout(() => {
         if (this.props.infinite) {
           this.setClones(
             this.state.slidesToShow,
@@ -366,7 +373,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       if (!this.props.infinite && isInRightEnd(this.state)) {
         const rewindBuffer =
           this.props.transitionDuration || defaultTransitionDuration;
-        setTimeout(() => {
+        Carousel.isInThrottleTimeout = setTimeout(() => {
           this.setIsInThrottle(false);
           this.resetAutoplayInterval();
           this.goToSlide(0, undefined, !!this.props.rewindWithAnimation);
@@ -393,7 +400,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     ) {
       if (isReachingTheEnd || isReachingTheStart) {
         this.isAnimationAllowed = false;
-        setTimeout(() => {
+        Carousel.transformTimeout = setTimeout(() => {
           this.setState({
             transform: nextPosition,
             currentSlide: nextSlide
@@ -434,7 +441,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       },
       () => {
         if (typeof afterChange === "function") {
-          setTimeout(() => {
+          Carousel.afterChangeTimeout = setTimeout(() => {
             afterChange(previousSlide, this.getState());
           }, this.props.transitionDuration || defaultTransitionDuration);
         }
@@ -468,7 +475,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
       },
       () => {
         if (typeof afterChange === "function") {
-          setTimeout(() => {
+          Carousel.afterChangeTimeout2 = setTimeout(() => {
             afterChange(previousSlide, this.getState());
           }, this.props.transitionDuration || defaultTransitionDuration);
         }
@@ -497,6 +504,13 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     if (this.itemsToShowTimeout) {
       clearTimeout(this.itemsToShowTimeout);
     }
+
+    Carousel.clonesTimeout && clearTimeout(Carousel.clonesTimeout);
+    Carousel.isInThrottleTimeout && clearTimeout(Carousel.isInThrottleTimeout);
+    Carousel.transformTimeout && clearTimeout(Carousel.transformTimeout);
+    Carousel.afterChangeTimeout && clearTimeout(Carousel.afterChangeTimeout);
+    Carousel.afterChangeTimeout2 && clearTimeout(Carousel.afterChangeTimeout2);
+    Carousel.afterChangeTimeout3 && clearTimeout(Carousel.afterChangeTimeout3);
   }
   public resetMoveStatus(): void {
     this.onMove = false;
@@ -699,7 +713,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
             (typeof skipCallbacks === "object" &&
               !skipCallbacks.skipAfterChange))
         ) {
-          setTimeout(() => {
+          Carousel.afterChangeTimeout3 = setTimeout(() => {
             afterChange(previousSlide, this.getState());
           }, this.props.transitionDuration || defaultTransitionDuration);
         }


### PR DESCRIPTION
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications. 
While running the tool and analyzing the code of react-multi-carousel, we saw that your project does a very good job of ensuring that all async operations are cancelled when the component unmounts. However, as per Memlab execution results, we found some dangling timers that were causing the memory to leak (screenshots below).

[before]
<img width="1278" alt="Screen Shot 2023-01-28 at 9 15 19 PM" src="https://user-images.githubusercontent.com/56495631/215295382-3915ed0b-9784-47b1-9d6a-616aa0b6dffb.png">
<br />
Hence we added the fix by clearing the timeouts and you can see the heap size and # of leaks reducing noticeably:
 <br />
<img width="1265" alt="Screen Shot 2023-01-28 at 8 55 21 PM" src="https://user-images.githubusercontent.com/56495631/215295394-130435d9-75f8-4b2e-ad33-7237c75127f1.png">

We used static variables, instead of normal ones, so that in future, even if the code changes for e.g encapsulating these timers in a nested function, the ID vars should still retain their correct (class) context, as opposed to volatile 'this' context.

We ran the unit test cases, and the results were the same as before our patch, i.e these patches had no effect on any case result.
You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering the maximum # of use cases.
Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in .txt form):
[multi-carousel-memlab-scenario.txt](https://github.com/YIZHUANG/react-multi-carousel/files/10528498/multi-carousel-memlab-scenario.txt)

Note that some other reported leaks (in Memlab) originated from Storybook, hence were ignored.